### PR TITLE
SYM-239: Install session-manager-plugin if needed and possible.

### DIFF
--- a/docs/sym.sh
+++ b/docs/sym.sh
@@ -95,7 +95,7 @@ semverLT() {
 # Sym Stuff
 
 die() {
-  printf "%s\n" "$@" >&2
+  printf "\e[31m%s\e[0m\n" "$@" >&2
   exit 1
 }
 

--- a/docs/sym.sh
+++ b/docs/sym.sh
@@ -164,4 +164,4 @@ installWithPipx || installWithBrew ||
 installSessionManagerPlugin ||
   die 'Successfully installed sym-cli but could not install session-manager-plugin;' "sym ssh won't work. To fix, please follow the instructions listed at:" https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
 
-echo 'Successfully installed sym-cli.'
+printf '\e[32mSuccessfully installed sym-cli.\e[0m\n'

--- a/docs/sym.sh
+++ b/docs/sym.sh
@@ -94,12 +94,16 @@ semverLT() {
 
 # Sym Stuff
 
+hasCommand() {
+  [ -x "$(command -v "$1")" ]
+}
+
 getPythonPath() {
   command -v python3.8 || command -v python3 || command -v python
 }
 
 ensureBrew() {
-  if ! [ -x "$(command -v brew)" ]; then
+  if ! hasCommand brew; then
     eval "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
     set +u    # Undo `set -u` that install.sh does.
     eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
@@ -107,8 +111,8 @@ ensureBrew() {
 }
 
 ensurePipx() {
-  if ! [ -x "$(command -v pipx)" ]; then
-    if [ -x "$(command -v brew)" ]; then
+  if ! hasCommand pipx; then
+    if hasCommand brew; then
       brew install pipx
     else
       $(getPythonPath) -m pip install --user pipx
@@ -119,7 +123,7 @@ ensurePipx() {
 
 ensurePython38() {
   if semverLT "$($(getPythonPath) --version | cut -c8-)" "3.8.0"; then
-    if [ -x "$(command -v pyenv)" ]; then
+    if hasCommand pyenv; then
       pyenv install 3.8.2
       pyenv shell 3.8.2
     else

--- a/docs/sym.sh
+++ b/docs/sym.sh
@@ -94,6 +94,11 @@ semverLT() {
 
 # Sym Stuff
 
+die() {
+  printf "%s\n" "$@" >&2
+  exit 1
+}
+
 hasCommand() {
   [ -x "$(command -v "$1")" ]
 }
@@ -147,5 +152,18 @@ installWithBrew() {
   brew upgrade symopsio/tap/sym >/dev/null 2>&1
 }
 
-installWithPipx || installWithBrew
+installSessionManagerPlugin() {
+  if ! hasCommand session-manager-plugin; then
+    if hasCommand brew; then
+      brew install session-manager-plugin
+    fi
+  fi
+}
 
+installWithPipx || installWithBrew ||
+  die 'Could not install sym-cli; please send us any error messages printed above.'
+
+installSessionManagerPlugin ||
+  die 'Successfully installed sym-cli but could not install session-manager-plugin;' "sym ssh won't work. To fix, please follow the instructions listed at:" https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+
+echo 'Successfully installed sym-cli.'

--- a/docs/sym.sh
+++ b/docs/sym.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/cloudflare/semver_bash/blob/master/semver.sh
-function semverParseInto() {
+semverParseInto() {
     local RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
     #MAJOR
     eval $2=`echo $1 | sed -e "s#$RE#\1#"`
@@ -13,7 +13,7 @@ function semverParseInto() {
     eval $5=`echo $1 | sed -e "s#$RE#\4#"`
 }
 
-function semverEQ() {
+semverEQ() {
     local MAJOR_A=0
     local MINOR_A=0
     local PATCH_A=0
@@ -48,7 +48,7 @@ function semverEQ() {
 
 }
 
-function semverLT() {
+semverLT() {
     local MAJOR_A=0
     local MINOR_A=0
     local PATCH_A=0
@@ -94,11 +94,11 @@ function semverLT() {
 
 # Sym Stuff
 
-function getPythonPath() {
+getPythonPath() {
   command -v python3.8 || command -v python3 || command -v python
 }
 
-function ensureBrew() {
+ensureBrew() {
   if ! [ -x "$(command -v brew)" ]; then
     eval "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
     set +u    # Undo `set -u` that install.sh does.
@@ -106,7 +106,7 @@ function ensureBrew() {
   fi
 }
 
-function ensurePipx() {
+ensurePipx() {
   if ! [ -x "$(command -v pipx)" ]; then
     if [ -x "$(command -v brew)" ]; then
       brew install pipx
@@ -117,7 +117,7 @@ function ensurePipx() {
   fi
 }
 
-function ensurePython38() {
+ensurePython38() {
   if semverLT "$($(getPythonPath) --version | cut -c8-)" "3.8.0"; then
     if [ -x "$(command -v pyenv)" ]; then
       pyenv install 3.8.2
@@ -129,7 +129,7 @@ function ensurePython38() {
   fi
 }
 
-function installWithPipx() {
+installWithPipx() {
   ensurePython38
   ensurePipx
   pipx ensurepath >/dev/null 2>&1
@@ -137,7 +137,7 @@ function installWithPipx() {
   pipx upgrade sym-cli >/dev/null 2>&1
 }
 
-function installWithBrew() {
+installWithBrew() {
   ensureBrew
   brew install symopsio/tap/sym
   brew upgrade symopsio/tap/sym >/dev/null 2>&1

--- a/docs/sym.sh
+++ b/docs/sym.sh
@@ -154,9 +154,7 @@ installWithBrew() {
 
 installSessionManagerPlugin() {
   if ! hasCommand session-manager-plugin; then
-    if hasCommand brew; then
-      brew install session-manager-plugin
-    fi
+    hasCommand brew && brew install session-manager-plugin
   fi
 }
 


### PR DESCRIPTION
Currently session-manager-plugin is installed via Homebrew only. Also, currently, Homebrew only has a session-manager-plugin formula for Mac, not Linux. So handle failure cases properly too.