### PR TITLE
Remove deprecated `bottle :unneeded` statement.

### DIFF
--- a/scripts/gen/build_formula.rb
+++ b/scripts/gen/build_formula.rb
@@ -50,8 +50,6 @@ class FormulaBuilder
             virtualenv_install_with_resources
           end
         else
-          bottle :unneeded
-
           if OS.mac?
             url "#{url('darwin')}"
             sha256 "#{sha('darwin')}"


### PR DESCRIPTION
This will go live the next time a release is cut.