### PR TITLE
[SYM-5191] Support symflow Apple Silicon builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commands:
             source ~/.bash_profile
 
             echo "=== Installing symflow with pipx"
-            PIP_CONSTRAINT=constraints.txt pipx --python python3.9 install sym-cli
+            PIP_CONSTRAINT=constraints.txt pipx install --python python3.9 sym-cli
             sym version
   test_pipx_install_ubuntu:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,14 @@ commands:
   test_pip_install_macos:
     steps:
       - run:
+          name: Install Python 3.9.5
+          description: |
+            Forcibly install Python 3.9.5 to match the configuration of the previous version of the CircleCI macOS
+            executor we were using before migrating from Intel to Apple Silicon resources.
+          command: |
+            brew install python@3.9.5
+            brew link --overwrite python@3.9.5
+      - run:
           name: Test symflow pip install
           command: |
             python3 -m pip install sym-flow-cli
@@ -27,10 +35,7 @@ commands:
       - run:
           name: Test sym pip install
           command: |
-            echo '=== Setting up Cython bug workaround: https://github.com/yaml/pyyaml/issues/601#issuecomment-1660180265'
-            echo 'cython < 3.0' > constraints.txt
-            
-            PIP_CONSTRAINT=constraints.txt python3 -m pip install sym-cli
+            python3 -m pip install sym-cli
             pyenv rehash
             sym version
   test_pip_install_ubuntu:
@@ -67,10 +72,7 @@ commands:
             symflow version
       - run:
           name: Test sym pip install
-          command: |
-            echo '=== Setting up Cython bug workaround: https://github.com/yaml/pyyaml/issues/601#issuecomment-1660180265'
-            echo 'cython < 3.0' > constraints.txt
-            
+          command: |          
             echo "=== Installing pipx with pip"
             python3 -m pip install pipx
             pyenv rehash
@@ -80,7 +82,7 @@ commands:
             source ~/.bash_profile
 
             echo "=== Installing symflow with pipx"
-            PIP_CONSTRAINT=constraints.txt pipx install sym-cli
+            pipx install sym-cli
             sym version
   test_pipx_install_ubuntu:
     steps:
@@ -110,7 +112,7 @@ commands:
           name: Test symflow (x86_64) macOS package install
           command: |
             curl -LO https://github.com/symopsio/sym-flow-cli-releases/releases/latest/download/sym-flow-cli-darwin-x86_64.pkg
-            sudo installer -pkg sym-flow-cli-darwin-x64.pkg -target /
+            sudo installer -pkg sym-flow-cli-darwin-x86_64.pkg -target /
             symflow version
       - run:
           name: Test sym macOS package install
@@ -124,7 +126,7 @@ commands:
           name: Test symflow (aarch64) macOS package install
           command: |
             curl -LO https://github.com/symopsio/sym-flow-cli-releases/releases/latest/download/sym-flow-cli-darwin-aarch64.pkg
-            sudo installer -pkg sym-flow-cli-darwin-x64.pkg -target /
+            sudo installer -pkg sym-flow-cli-darwin-aarch64.pkg -target /
             symflow version
   test_dpkg_install:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,12 +91,12 @@ commands:
             echo "Installing sym with pipx"
             pipx install sym-cli
             sym version
-  test_macos_package_install:
+  test_macos_package_install_x86_64:
     steps:
       - run:
-          name: Test symflow macOS package install
+          name: Test symflow (x86_64) macOS package install
           command: |
-            curl -LO https://github.com/symopsio/sym-flow-cli-releases/releases/latest/download/sym-flow-cli-darwin-x64.pkg
+            curl -LO https://github.com/symopsio/sym-flow-cli-releases/releases/latest/download/sym-flow-cli-darwin-x86_64.pkg
             sudo installer -pkg sym-flow-cli-darwin-x64.pkg -target /
             symflow version
       - run:
@@ -105,6 +105,14 @@ commands:
             curl -LO https://github.com/symopsio/sym-cli-releases/releases/latest/download/sym-cli-darwin-x64.pkg
             sudo installer -pkg sym-cli-darwin-x64.pkg -target /
             sym version
+  test_macos_package_install_aarch64:
+    steps:
+      - run:
+          name: Test symflow (aarch64) macOS package install
+          command: |
+            curl -LO https://github.com/symopsio/sym-flow-cli-releases/releases/latest/download/sym-flow-cli-darwin-aarch64.pkg
+            sudo installer -pkg sym-flow-cli-darwin-x64.pkg -target /
+            symflow version
   test_dpkg_install:
     steps:
       - run:
@@ -168,13 +176,23 @@ jobs:
       - checkout:
           path: ~/project
       - test_pipx_install_macos
-  test_macos_package_install:
+  test_macos_package_install_x86_64:
+    resource_class: macos.m1.medium.gen1
     executor:
       name: macos
     steps:
       - checkout:
           path: ~/project
-      - test_macos_package_install
+      - macos/install-rosetta
+      - test_macos_package_install_x86_64
+  test_macos_package_install_aarch64:
+    resource_class: macos.m1.medium.gen1
+    executor:
+      name: macos
+    steps:
+      - checkout:
+          path: ~/project
+      - test_macos_package_install_aarch64
   test_dpkg_install:
     executor:
       name: ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,11 @@ commands:
       - run:
           name: Test sym pip install
           command: |
-            python3.9 -m pip install sym-cli
+            echo '=== Setting up Cython bug workaround: https://github.com/yaml/pyyaml/issues/601#issuecomment-1660180265'
+            echo 'cython < 3.0' > constraints.txt
+            
+            PIP_CONSTRAINT=constraints.txt python3.9 -m pip install sym-cli
+
             pyenv rehash
             sym version
   test_pip_install_ubuntu:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commands:
             source ~/.bash_profile
 
             echo "=== Installing symflow with pipx"
-            PIP_CONSTRAINT=constraints.txt pipx install sym-cli
+            PIP_CONSTRAINT=constraints.txt pipx --python python3.9 install sym-cli
             sym version
   test_pipx_install_ubuntu:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,8 @@ workflows:
       - test_pip_install_macos
       - test_pip_install_ubuntu
       - test_brew_install
-      - test_macos_package_install
+      - test_macos_package_install_x86_64
+      - test_macos_package_install_aarch64
       - test_dpkg_install
       - test_pipx_install_ubuntu
       - test_pipx_install_macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ executors:
       HOMEBREW_NO_AUTO_UPDATE: "1"
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
 
+orbs:
+  macos: circleci/macos@2.4.0
+
 commands:
   test_pip_install_macos:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ commands:
 
 jobs:
   test_brew_install:
+    resource_class: macos.m1.medium.gen1
     executor:
       name: macos
     steps:
@@ -152,6 +153,7 @@ jobs:
           path: ~/project
       - test_brew_install
   test_pip_install_macos:
+    resource_class: macos.m1.medium.gen1
     executor:
       name: macos
     steps:
@@ -173,6 +175,7 @@ jobs:
           path: ~/project
       - test_pipx_install_ubuntu
   test_pipx_install_macos:
+    resource_class: macos.m1.medium.gen1
     executor:
       name: macos
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,13 @@ commands:
           name: Test symflow pip install
           command: |
             python3 -m pip install sym-flow-cli
+            pyenv rehash
             symflow version
       - run:
           name: Test sym pip install
           command: |
             python3 -m pip install sym-cli
+            pyenv rehash
             sym version
   test_pip_install_ubuntu:
     steps:
@@ -50,6 +52,7 @@ commands:
             # for some reason we need to call pip as a python3 module specifically. However,
             # this causes the ubuntu version to fail. This is why they're separate.
             python3 -m pip install pipx
+            pyenv rehash
             pipx ensurepath
 
             echo "=== Sourcing ~/.bash_profile to apply PATH changes in this session"
@@ -64,6 +67,7 @@ commands:
           command: |
             echo "=== Installing pipx with pip"
             python3 -m pip install pipx
+            pyenv rehash
             pipx ensurepath
 
             echo "=== Sourcing ~/.bash_profile to apply PATH changes in this session"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,11 @@ commands:
       - run:
           name: Install Python 3.9
           description: |
-            Forcibly install Python 3.9 to match the configuration of the previous version of the CircleCI macOS
-            executor we were using before migrating from Intel to Apple Silicon resources.
+            Install Python 3.9, which was what was available in  the previous version of the CircleCI macOS executor
+            we were using before migrating from Intel to Apple Silicon resources. It can be used by calling
+            `python3.9` directly; `python3` will continue to point to the system Python.
           command: |
             brew install python@3.9
-            brew link --overwrite python@3.9
       - run:
           name: Test symflow pip install
           command: |
@@ -59,11 +59,11 @@ commands:
       - run:
             name: Install Python 3.9
             description: |
-              Forcibly install Python 3.9 to match the configuration of the previous version of the CircleCI macOS
-              executor we were using before migrating from Intel to Apple Silicon resources.
+              Install Python 3.9, which was what was available in  the previous version of the CircleCI macOS executor
+              we were using before migrating from Intel to Apple Silicon resources. It can be used by calling
+              `python3.9` directly; `python3` will continue to point to the system Python.
             command: |
               brew install python@3.9
-              brew link --overwrite python@3.9
       - run:
           name: Test symflow pipx install
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,10 @@ commands:
       - run:
           name: Test sym pip install
           command: |
-            python3 -m pip install sym-cli
+            echo '=== Setting up Cython bug workaround: https://github.com/yaml/pyyaml/issues/601#issuecomment-1660180265'
+            echo 'cython < 3.0' > constraints.txt
+            
+            PIP_CONSTRAINT=constraints.txt python3 -m pip install sym-cli
             pyenv rehash
             sym version
   test_pip_install_ubuntu:
@@ -65,6 +68,9 @@ commands:
       - run:
           name: Test sym pip install
           command: |
+            echo '=== Setting up Cython bug workaround: https://github.com/yaml/pyyaml/issues/601#issuecomment-1660180265'
+            echo 'cython < 3.0' > constraints.txt
+            
             echo "=== Installing pipx with pip"
             python3 -m pip install pipx
             pyenv rehash
@@ -74,7 +80,7 @@ commands:
             source ~/.bash_profile
 
             echo "=== Installing symflow with pipx"
-            pipx install sym-cli
+            PIP_CONSTRAINT=constraints.txt pipx install sym-cli
             sym version
   test_pipx_install_ubuntu:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,11 @@ commands:
           name: Test symflow pip install
           command: |
             python3 -m pip install sym-flow-cli
-            pyenv rehash
             symflow version
       - run:
           name: Test sym pip install
           command: |
-            python3 -m pip install sym-cli
-            pyenv rehash
+            python3.9 -m pip install sym-cli
             sym version
   test_pip_install_ubuntu:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,14 @@ commands:
   test_pipx_install_macos:
     steps:
       - run:
+            name: Install Python 3.9
+            description: |
+              Forcibly install Python 3.9 to match the configuration of the previous version of the CircleCI macOS
+              executor we were using before migrating from Intel to Apple Silicon resources.
+            command: |
+              brew install python@3.9
+              brew link --overwrite python@3.9
+      - run:
           name: Test symflow pipx install
           command: |
             echo "=== Installing pipx with pip"
@@ -75,10 +83,13 @@ commands:
 
             symflow version
       - run:
-          name: Test sym pip install
-          command: |          
+          name: Test sym pipx install
+          command: |
+            echo '=== Setting up Cython bug workaround: https://github.com/yaml/pyyaml/issues/601#issuecomment-1660180265'
+            echo 'cython < 3.0' > constraints.txt
+
             echo "=== Installing pipx with pip"
-            python3 -m pip install pipx
+            python3.9 -m pip install pipx
             pyenv rehash
             pipx ensurepath
 
@@ -86,7 +97,7 @@ commands:
             source ~/.bash_profile
 
             echo "=== Installing symflow with pipx"
-            pipx install sym-cli
+            PIP_CONSTRAINT=constraints.txt pipx install sym-cli
             sym version
   test_pipx_install_ubuntu:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,13 @@ commands:
   test_pip_install_macos:
     steps:
       - run:
-          name: Install Python 3.9.5
+          name: Install Python 3.9
           description: |
-            Forcibly install Python 3.9.5 to match the configuration of the previous version of the CircleCI macOS
+            Forcibly install Python 3.9 to match the configuration of the previous version of the CircleCI macOS
             executor we were using before migrating from Intel to Apple Silicon resources.
           command: |
-            brew install python@3.9.5
-            brew link --overwrite python@3.9.5
+            brew install python@3.9
+            brew link --overwrite python@3.9
       - run:
           name: Test symflow pip install
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,13 @@ commands:
           name: Test symflow pip install
           command: |
             python3 -m pip install sym-flow-cli
+            pyenv rehash
             symflow version
       - run:
           name: Test sym pip install
           command: |
             python3.9 -m pip install sym-cli
+            pyenv rehash
             sym version
   test_pip_install_ubuntu:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: cimg/python:3.8.11
   macos:
     macos:
-      xcode: "12.5.1"
+      xcode: "14.2.0"
     environment:
       LANG: "en_US.UTF-8"
       HOMEBREW_NO_AUTO_UPDATE: "1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
       - run:
           name: Install Python 3.9
           description: |
-            Install Python 3.9, which was what was available in  the previous version of the CircleCI macOS executor
+            Install Python 3.9, which was what was available in the previous version of the CircleCI macOS executor
             we were using before migrating from Intel to Apple Silicon resources. It can be used by calling
             `python3.9` directly; `python3` will continue to point to the system Python.
           command: |
@@ -59,7 +59,7 @@ commands:
       - run:
             name: Install Python 3.9
             description: |
-              Install Python 3.9, which was what was available in  the previous version of the CircleCI macOS executor
+              Install Python 3.9, which was what was available in the previous version of the CircleCI macOS executor
               we were using before migrating from Intel to Apple Silicon resources. It can be used by calling
               `python3.9` directly; `python3` will continue to point to the system Python.
             command: |

--- a/scripts/gen/build_formula.rb
+++ b/scripts/gen/build_formula.rb
@@ -52,8 +52,7 @@ class FormulaBuilder
           end
         else
           if OS.mac?
-            url "#{url('darwin')}"
-            sha256 "#{sha('darwin')}"
+            #{macos_block.strip}
           else
             url "#{url('linux')}"
             sha256 "#{sha('linux')}"
@@ -81,12 +80,31 @@ class FormulaBuilder
     end
   end
 
-  def url(platform)
-    "https://github.com/symopsio/#{cli_name}-releases/releases/download/v#{version}/#{cli_name}-#{platform}-x64.tar.gz"
+  def macos_block
+    if cli_name == 'sym-flow-cli'
+      <<~RUBY
+        if Hardware::CPU.arm?
+          url "#{url('darwin', 'aarch64')}"
+          sha256 "#{sha('darwin', 'aarch64')}"
+        else
+          url "#{url('darwin', 'x86_64')}"
+          sha256 "#{sha('darwin', 'x86_64')}"
+        end
+      RUBY
+    else
+      <<~RUBY
+        url "#{url('darwin')}"
+        sha256 "#{sha('darwin')}"
+      RUBY
+    end
   end
 
-  def sha(platform)
-    `curl -L #{url(platform)} | shasum -a 256`.strip.split(/\s/).first
+  def url(platform, arch = 'x64')
+    "https://github.com/symopsio/#{cli_name}-releases/releases/download/v#{version}/#{cli_name}-#{platform}-#{arch}.tar.gz"
+  end
+
+  def sha(platform, arch = 'x64')
+    `curl -L #{url(platform, arch)} | shasum -a 256`.strip.split(/\s/).first
   end
 
   def top_block


### PR DESCRIPTION
## Description
**⚠️ CAUTION: This PR must be merged _before_ the corresponding sym-flow-cli PR ([#243](<https://github.com/symopsio/sym-flow-cli/pull/243>)).**

This PR updates the `build_formula.rb` script used to generate Homebrew formula files after a release of our CLI tools. Specifically, sym-flow-cli will shortly be producing both Apple Silicon (`aarch64`) and Intel (`x86_64`) builds, and this allows Homebrew to automaticaly install the correct distribution for a given environment. The technique utilized to identify the environment is described in [Homebrew's documentation here](<https://docs.brew.sh/Formula-Cookbook#handling-different-system-configurations>).

This PR also updates the CircleCI tests to look for the new sym-flow-cli packages produced by the new build process. It also updates the macOS jobs to happen on Apple Silicon CircleCI resources due to the impending deprecation of macOS Intel resources. Likewise, **some CircleCI test failures are expected for now** (see below).

Linear ticket: [SYM-5179](<https://linear.app/symops/issue/SYM-5179/>).

## Testing
Unfortunately, due to their interdependent nature (and that they both depend on GitHub releases), it won't be possible to fully test this PR except in the CI environment after this PR and the corresponding sym-flow-cli PR are both merged.

Note that it is expected that some CircleCI tests will fail until [sym-flow-cli PR #243](<https://github.com/symopsio/sym-flow-cli/pull/243>) is merged and we have a first release of sym-flow-cli with the new build pipeline:

- test_macos_package_install_aarch64: Will fail to find the aarch64 package for sym-flow-cli since it hasn't yet been released
- test_macos_package_install_x86_64: Will fail to find the x86_64 specific package for sym-flow-cli since it is currently being built under a different name
- test_brew_install: Will fail because Rosetta 2 is not being installed for this test, with the expectation that once the new sym-flow-cli build process is in place, it should be able to pull proper Apple Silicon binaries from Homebrew

Failures in tests other than these three are _not_ expected, and of course all tests should pass once this PR and [sym-flow-cli PR #243](<https://github.com/symopsio/sym-flow-cli/pull/243>) are merged and we release sym-flow-cli at least once.