### PR TITLE
[SYM-5191] A couple final fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,13 +157,15 @@ commands:
             curl -LO https://github.com/symopsio/sym-cli-releases/releases/latest/download/sym-cli-linux-x64.deb
             sudo dpkg -i sym-cli-linux-x64.deb
             sym version
-  test_brew_install:
+  test_brew_install_symflow_cli:
     steps:
       - run:
           name: Test symflow brew Formula
           command: |
             brew install --formula ~/project/Formula/symflow.rb
             symflow version
+  test_brew_install_sym_cli:
+    steps:
       - run:
           name: Test sym brew Formula
           command: |
@@ -171,14 +173,23 @@ commands:
             sym version
 
 jobs:
-  test_brew_install:
+  test_brew_install_symflow_cli:
     resource_class: macos.m1.medium.gen1
     executor:
       name: macos
     steps:
       - checkout:
           path: ~/project
-      - test_brew_install
+      - test_brew_install_symflow_cli
+  test_brew_install_sym_cli:
+    resource_class: macos.m1.medium.gen1
+    executor:
+      name: macos
+    steps:
+      - checkout:
+          path: ~/project
+      - macos/install-rosetta
+      - test_brew_install_sym_cli
   test_pip_install_macos:
     resource_class: macos.m1.medium.gen1
     executor:
@@ -239,7 +250,8 @@ workflows:
     jobs:
       - test_pip_install_macos
       - test_pip_install_ubuntu
-      - test_brew_install
+      - test_brew_install_symflow_cli
+      - test_brew_install_sym_cli
       - test_macos_package_install_x86_64
       - test_macos_package_install_aarch64
       - test_dpkg_install

--- a/scripts/gen/build_formula.rb
+++ b/scripts/gen/build_formula.rb
@@ -52,7 +52,7 @@ class FormulaBuilder
           end
         else
           if OS.mac?
-            #{macos_block.strip}
+            #{indented_macos_block.strip}
           else
             url "#{url('linux')}"
             sha256 "#{sha('linux')}"
@@ -78,6 +78,10 @@ class FormulaBuilder
       warn "Invalid formula #{formula}"
       exit 1
     end
+  end
+
+  def indented_macos_block
+    macos_block.lines.map { |line| "      #{line}" }.join
   end
 
   def macos_block


### PR DESCRIPTION
- Split test_brew_install job into two, one for symflow and one for sym-cli, so that we can install Rosetta for the sym-cli one (since sym-cli is still x86-only)
- Fix the build_formula.rb script to properly indent the new macOS block

This time was able to test the script locally so can confirm that the new indenting is good. The CircleCI run of this PR should confirm the tests too (i.e., they should all pass this time _except_ for test_brew_install_symflow_cli since there hasn't been a successful Homebrew release of symflow with Apple Silicon yet).